### PR TITLE
Fixed wget Figshare Data download instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ For processed data, download the compressed folders and place them in `data/proc
 cd data
 mkdir processed
 cd processed
-wget https://figshare.com/ndownloader/files/43624557
+wget --content-disposition https://ndownloader.figshare.com/files/43624557
 tar -xzvf torch_data.tar.gz
 cd ../
-wget https://figshare.com/ndownloader/files/43632327
+wget --content-disposition https://ndownloader.figshare.com/files/43632327
 tar -xzvf splits.tar.gz
 ```
 


### PR DESCRIPTION
Hi,

Really nice paper and code. I had trouble downloading the data from figshare using the provided wget command. It works fine in the browser but not through wget:

<img width="945" height="112" alt="Screenshot 2025-08-12 at 10 17 37" src="https://github.com/user-attachments/assets/7d9c206c-6d85-47c7-bee9-57a30beab1e8" />

My provided edit to the README, hopefully, fixes that. 

Cheers!